### PR TITLE
Disable metis for Android. Skip second opencv build 

### DIFF
--- a/scripts/android/build.sh
+++ b/scripts/android/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-: "${BUILD_OPENCV:=ON}"
+: "${BUILD_EIGEN:=ON}"
 : "${USE_SLAM:=ON}"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -17,18 +17,14 @@ else
     exit 1
 fi
 
-ROOT_DIR=`pwd`
-
-# First, build OpenCV
-if [[ $BUILD_OPENCV == "ON" ]]; then
-  cp scripts/android/opencv.config.py opencv/platforms/android
-  cd opencv/platforms/android
-  python2 build_sdk.py --no_samples_build --config="opencv.config.py" "$ROOT_DIR/build/opencv-sdk"
-  rm opencv.config.py
-  cd "$ROOT_DIR"
+# Build Eigen
+# TODO: Move to component/eigen.sh
+if [[ $BUILD_EIGEN == "ON" ]]; then
+  ./scripts/build.sh eigen
 fi
 
-export OPENCV_DIR=$ROOT_DIR/build/opencv-sdk/OpenCV-android-sdk/sdk/native/jni
+ROOT_DIR=`pwd`
+
 export BUILD_VISUALIZATIONS=OFF
 export ANDROID_CROSS_COMPILING_HACKS=ON
 

--- a/scripts/components/opencv.sh
+++ b/scripts/components/opencv.sh
@@ -22,6 +22,12 @@ if [[ $IOS_CROSS_COMPILING_HACKS == "ON" ]]; then
     cp "$ROOT_DIR"/scripts/ios/"$file" $BUILD_DIR/lib/opencv/build/build-"$TARGET_ARCHITECTURE"-iphoneos/install/
   done
 
+elif [[ $ANDROID_CROSS_COMPILING_HACKS == "ON" ]]; then
+  # TODO: Move OpenCV build here?
+  if [[ -z $OPENCV_DIR ]]; then
+    echo "WARNING! OpenCV should have been built previously!"
+    exit 1
+  fi
 else
   CUR_DIR=$WORK_DIR/opencv
 

--- a/scripts/components/opencv.sh
+++ b/scripts/components/opencv.sh
@@ -23,11 +23,17 @@ if [[ $IOS_CROSS_COMPILING_HACKS == "ON" ]]; then
   done
 
 elif [[ $ANDROID_CROSS_COMPILING_HACKS == "ON" ]]; then
-  # TODO: Move OpenCV build here?
+  # Build OpenCV only once
   if [[ -z $OPENCV_DIR ]]; then
-    echo "WARNING! OpenCV should have been built previously!"
-    exit 1
+    cd "$ROOT_DIR"
+    cp scripts/android/opencv.config.py opencv/platforms/android
+    cd opencv/platforms/android
+    CMAKE_FLAGS="" CC="" CXX="" CXX_FLAGS="" LDFLAGS="" python2 build_sdk.py --no_samples_build --config="opencv.config.py" "$ROOT_DIR/build/opencv-sdk"
+    rm opencv.config.py
+    cd "$ROOT_DIR"
+    OPENCV_DIR=$ROOT_DIR/build/opencv-sdk/OpenCV-android-sdk/sdk/native/jni
   fi
+
 else
   CUR_DIR=$WORK_DIR/opencv
 

--- a/scripts/components/suitesparse.sh
+++ b/scripts/components/suitesparse.sh
@@ -20,7 +20,8 @@ if [[ $SUITESPARSE_CF ]]; then
   SUITESPARSE_FLAGS+=("CF=$SUITESPARSE_CF")
 fi
 
-if [ -z $IOS_CROSS_COMPILING_HACKS ]; then
+# No metis for iOS or Android
+if [ -z $IOS_CROSS_COMPILING_HACKS && -z $ANDROID_CROSS_COMPILING_HACKS ]; then
   make metisinstall "${SUITESPARSE_FLAGS[@]}"
 fi
 

--- a/scripts/mobile-cv-suite-config.cmake
+++ b/scripts/mobile-cv-suite-config.cmake
@@ -89,8 +89,12 @@ if (_MCS_USE_SLAM)
     ${_MCS_LIBS}/libsuitesparseconfig${CMAKE_SHARED_LIBRARY_SUFFIX})
 
   if(NOT(IOS))
+    if(NOT(ANDROID))
+      list(APPEND _MCS_INTERFACE_LIBS
+        ${_MCS_LIBS}/libmetis${CMAKE_SHARED_LIBRARY_SUFFIX}
+      )
+    endif()
     list(APPEND _MCS_INTERFACE_LIBS
-      ${_MCS_LIBS}/libmetis${CMAKE_SHARED_LIBRARY_SUFFIX}
       ${_MCS_LIBS}/libopenblas.a
     )
   endif()


### PR DESCRIPTION
I didn't investigate why the mobile-cv-suite needs to be built twice as the README suggests. Should I look into that and align how OpenCV build is done for other platforms @oseiskar ? 