### PR TITLE
Fix OpenCV build finding Eigen build outside the workspace.

### DIFF
--- a/scripts/components/opencv.sh
+++ b/scripts/components/opencv.sh
@@ -55,6 +55,7 @@ else
   #   * Other unused stuff: Quirc (QR-codes), Protobuf support
   #
   $CMAKE $CMAKE_FLAGS \
+    -DCMAKE_PREFIX_PATH="$INSTALL_PREFIX" \
     -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
     -DBUILD_LIST=core,calib3d,features2d,highgui,video,videoio \
     -DWITH_TIFF=OFF -DWITH_JASPER=OFF -DWITH_JPEG=OFF -DWITH_WEBP=OFF -DWITH_OPENEXR=OFF \


### PR DESCRIPTION
Without this change, for me the OpenCV build found a (broken) Eigen build at some remote directory unrelated to the current build, which then broke the OpenCV build. The `CMAKE_PREFIX_PATH` variable is already used like this in the `g2o` and `Eigen` builds.