### PR TITLE
Package Android build artifacts and licenses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,15 @@ jobs:
         name: build-manual
         path: |
           build/mobile-cv-suite.tar.gz
+    - uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: |
+          build/host/include/
+          build/host/lib/*.a*
+          build/host/lib/*.so*
+          build/host/share/doc
+          build/host/share/licenses
+          build/android
+          scripts/mobile-cv-suite-config.cmake
+          mobile-cv-suite-config.cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,22 +21,10 @@ jobs:
     - name: Build for Android
       run: |
         BUILD_VISUALIZATIONS=OFF BUILD_EIGEN=OFF ./scripts/android/build.sh
-    - name: Package (manual)
+    - name: Package
       run: ./scripts/package.sh
     - uses: actions/upload-artifact@v2
       with:
-        name: build-manual
+        name: artifacts
         path: |
           build/mobile-cv-suite.tar.gz
-    - uses: actions/upload-artifact@v2
-      with:
-        name: build
-        path: |
-          build/host/include/
-          build/host/lib/*.a*
-          build/host/lib/*.so*
-          build/host/share/doc
-          build/host/share/licenses
-          build/android
-          scripts/mobile-cv-suite-config.cmake
-          mobile-cv-suite-config.cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
     - name: Build for Android
       run: |
         BUILD_VISUALIZATIONS=OFF BUILD_EIGEN=OFF ./scripts/android/build.sh
-    - name: Package Linux
+    - name: Package (manual)
       run: ./scripts/package.sh
     - uses: actions/upload-artifact@v2
       with:
-        name: linux-build
+        name: build-manual
         path: |
           build/mobile-cv-suite.tar.gz

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,10 +30,12 @@ export CXX
 
 ROOT_DIR=`pwd`
 BUILD_DIR=$ROOT_DIR/build/$TARGET_ARCHITECTURE
+LICENSE_DIR=$ROOT_DIR/build/licenses
 WORK_DIR=$BUILD_DIR/work
 SRC_DIR=$ROOT_DIR
 SCRIPT_DIR=$ROOT_DIR/scripts/components
 
+mkdir -p $LICENSE_DIR
 INSTALL_PREFIX=$BUILD_DIR
 
 if [ "$#" -ge 1 ]; then

--- a/scripts/components/dbow2.sh
+++ b/scripts/components/dbow2.sh
@@ -16,3 +16,5 @@ $CMAKE $CMAKE_FLAGS $IOS_FLAGS \
     -DBUILD_SHARED_LIBS=OFF \
     "$SRC_DIR/DBoW2"
 $CMAKE --build . --config Release --target install $CMAKE_MAKE_FLAGS
+
+cp "$SRC_DIR/DBoW2/LICENSE.txt" $LICENSE_DIR/DBoW2.txt

--- a/scripts/components/eigen.sh
+++ b/scripts/components/eigen.sh
@@ -35,3 +35,9 @@ else
       "$SRC_DIR/eigen"
   $CMAKE --build . --config Release --target install $CMAKE_MAKE_FLAGS
 fi
+
+mkdir -p $LICENSE_DIR/Eigen
+cp "$SRC_DIR/eigen/COPYING.MPL2" $LICENSE_DIR/Eigen
+cp "$SRC_DIR/eigen/COPYING.MINPACK" $LICENSE_DIR/Eigen # stuff in the unsupported/ dir
+# warning: there is an LGPL-licensed header included: Eigen/src/IterativeLinearSolvers/IncompleteLUT.h
+cp "$SRC_DIR/eigen/COPYING.LGPL" $LICENSE_DIR/Eigen

--- a/scripts/components/g2o.sh
+++ b/scripts/components/g2o.sh
@@ -32,3 +32,5 @@ if [ $IOS_CROSS_COMPILING_HACKS ]; then
   cd $INSTALL_PREFIX/lib
   install_name_tool -id @rpath/libg2o_csparse_extension.dylib libg2o_csparse_extension.dylib
 fi
+
+cp "$SRC_DIR/g2o/doc/license-bsd.txt" $LICENSE_DIR/g2o.txt

--- a/scripts/components/jsonl-recorder.sh
+++ b/scripts/components/jsonl-recorder.sh
@@ -18,3 +18,6 @@ $CMAKE $CMAKE_FLAGS \
     -DOpenCV_DIR="$OPENCV_DIR" \
     "$SRC_DIR/jsonl-recorder"
 $CMAKE --build . --config Release --target install $CMAKE_MAKE_FLAGS
+
+cp "$SRC_DIR/jsonl-recorder/LICENSE" $LICENSE_DIR/jsonl-recorder.txt
+cp "$SRC_DIR/json/LICENSE.MIT" $LICENSE_DIR/json.txt

--- a/scripts/components/loguru/build.sh
+++ b/scripts/components/loguru/build.sh
@@ -14,3 +14,6 @@ $CMAKE $CMAKE_FLAGS \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     "$SRC_DIR/scripts/components/loguru"
 $CMAKE --build . --config Release --target install $CMAKE_MAKE_FLAGS
+
+# License: public domain
+cp "$SRC_DIR/loguru/README.md" $LICENSE_DIR/Loguru.md

--- a/scripts/components/openblas.sh
+++ b/scripts/components/openblas.sh
@@ -14,3 +14,5 @@ $CMAKE $CMAKE_FLAGS $OPENBLAS_CMAKE_FLAGS \
     -DUSE_THREAD=OFF \
     "$SRC_DIR/OpenBLAS"
 $CMAKE --build . --config Release --target install $CMAKE_MAKE_FLAGS
+
+cp "$SRC_DIR/OpenBLAS/LICENSE" $LICENSE_DIR/OpenBLAS.txt

--- a/scripts/components/opencv.sh
+++ b/scripts/components/opencv.sh
@@ -70,8 +70,6 @@ else
 
 fi
 
-
-
-
-
-
+if [[ $TARGET_ARCHITECTURE == "host" ]]; then
+  cp -R $BUILD_DIR/share/licenses/opencv4 $LICENSE_DIR
+fi

--- a/scripts/components/pangolin.sh
+++ b/scripts/components/pangolin.sh
@@ -10,3 +10,5 @@ mkdir -p "$CUR_DIR"
 cd "$CUR_DIR"
 $CMAKE $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" "$SRC_DIR/Pangolin"
 make -j$NPROC install
+
+cp "$SRC_DIR/Pangolin/LICENCE" $LICENSE_DIR/Pangolin.txt

--- a/scripts/components/suitesparse.sh
+++ b/scripts/components/suitesparse.sh
@@ -8,6 +8,7 @@ if [[ $DO_CLEAR == "ON" ]]; then
   rm -rf "$SRC_DIR/suitesparse" && git submodule update "$SRC_DIR/suitesparse"
 fi
 
+ABS_LICENSE_DIR=`realpath $LICENSE_DIR`
 cd "$SRC_DIR/suitesparse"
 SUITESPARSE_FLAGS=(
   CUDA=no
@@ -24,6 +25,8 @@ fi
 if [[ -z $IOS_CROSS_COMPILING_HACKS && -z $ANDROID_CROSS_COMPILING_HACKS ]]; then
   make metisinstall "${SUITESPARSE_FLAGS[@]}"
 fi
+cp metis-5.1.0/LICENSE.txt $ABS_LICENSE_DIR/METIS_LICENSE.txt
+cp metis-5.1.0/README.txt $ABS_LICENSE_DIR/METIS_README.txt
 
 # Metis: Apache 2
 # AMD, CAMD, COLAMD, CCOLAMD: BSD
@@ -47,6 +50,7 @@ for lib in AMD BTF CAMD CCOLAMD COLAMD CXSparse; do
   if [ $ANDROID_CROSS_COMPILING_HACKS ]; then
     python "$ROOT_DIR/scripts/android/drop_library_soname_suffixes.py" "$INSTALL_PREFIX/lib"
   fi
+  cp Doc/License.txt $ABS_LICENSE_DIR/${lib}.txt
   cd ..
 done
 

--- a/scripts/components/theia.sh
+++ b/scripts/components/theia.sh
@@ -14,3 +14,5 @@ $CMAKE $CMAKE_FLAGS \
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
   "$SRC_DIR/Theia"
 $CMAKE --build . --config Release --target install $CMAKE_MAKE_FLAGS
+
+cp "$SRC_DIR/Theia/license.txt" $LICENSE_DIR/Theia.txt

--- a/scripts/components/yaml-cpp.sh
+++ b/scripts/components/yaml-cpp.sh
@@ -20,3 +20,5 @@ if [ -f "$INSTALL_PREFIX/lib64/libyaml-cpp.a" ]; then
   mkdir -p "$INSTALL_PREFIX/lib"
   cp "$INSTALL_PREFIX/lib64/libyaml-cpp.a" "$INSTALL_PREFIX/lib/libyaml-cpp.a"
 fi
+
+cp "$SRC_DIR/yaml-cpp/LICENSE" $LICENSE_DIR/yaml-cpp.txt

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -2,10 +2,11 @@
 # Package built artefacts as an archive file
 set -eux
 # TODO: OSX build
-DIR=build/host
-(find $DIR/include/ \
-  && find $DIR/lib/ -name "*.a*" -o -name "*.so*" \
-  && find $DIR/share/doc/ && find $DIR/share/licenses/ &&
-  echo scripts/mobile-cv-suite-config.cmake &&
+DIR=build
+(find $DIR/host/include/ \
+  && find $DIR/host/lib/ -name "*.a*" -o -name "*.so*" \
+  && find $DIR/host/share/doc/ -type f && find $DIR/host/share/licenses/ -type f \
+  && find $DIR/android/ -type f \
+  && echo scripts/mobile-cv-suite-config.cmake && \
   echo mobile-cv-suite-config.cmake) | \
-  tar -cf build/mobile-cv-suite.tar.gz -T -
+  tar -c -T - | gzip --best > build/mobile-cv-suite.tar.gz

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -5,7 +5,7 @@ set -eux
 DIR=build
 (find $DIR/host/include/ \
   && find $DIR/host/lib/ -name "*.a*" -o -name "*.so*" \
-  && find $DIR/host/share/doc/ -type f && find $DIR/host/share/licenses/ -type f \
+  && find $DIR/licenses/ -type f \
   && find $DIR/android/ -type f \
   && echo scripts/mobile-cv-suite-config.cmake && \
   echo mobile-cv-suite-config.cmake) | \


### PR DESCRIPTION
 * package Android build artefacts
 * and licenses for all included libraries
 * change gzip compression level to `--best` (reduces the size of the package by hundreds of MBs)

The `artefacts.zip` (which only contains `mobile-cv-suite.tar.gz`) can be used by manually (for #6) as follows
 1. download
 1. extract
 1. create a Git tag (e.g., `v1.0.0`)
 1. create a Github _Release_ from that tag
 1. attach  `mobile-cv-suite.tar.gz` into that Release

Then it can be downloaded by, e.g., CMake build scripts of dependent projects.