### PR TITLE
Attempt to fix Android build on Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Github has apparently changed the build environment in Actions, breaking our Android builds. Quite subtle: both the last working build and the first broken build use "Ubuntu 20.04" but the Android tools have been updated in the latest virtual environment version https://github.com/actions/virtual-environments/blob/ubuntu20/20210111.1/images/linux/Ubuntu2004-README.md#android

EDIT: Unfortunately, the old environment does not seem to be available anymore as also Ubuntu 18 was updated to use the new NDK/tools (as described here https://github.com/actions/virtual-environments/issues/2420). This will cause some headache with the plain Make deps (CMake deps are presumably fine). Some more info
 * https://github.com/android/ndk/wiki/Changelog-r22
 * https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md 

At this point, just installing the old and working build environment into a Docker image seems like a more attractive option than reading those ^